### PR TITLE
Use next unstable_cache to cache db calls across requests

### DIFF
--- a/src/app/lib/log.ts
+++ b/src/app/lib/log.ts
@@ -3,7 +3,10 @@ import winston from 'winston';
 
 const log = winston.createLogger({
     level: 'info',
-    format: winston.format.json(),
+    format: winston.format.combine(
+        winston.format.splat(),
+        winston.format.json()
+    ),
     transports: [new winston.transports.Console()]
 })
 


### PR DESCRIPTION
This may introduce stale data bugs, so I added a bunch of logging around db requests. Overall should make the site much faster. Enable fmtstr logging in Winston. 