### PR TITLE
Send verification codes instead of magic links

### DIFF
--- a/src/app/login/auth-error.tsx
+++ b/src/app/login/auth-error.tsx
@@ -13,7 +13,7 @@ export default function AuthError() {
 }
 
 const errorMessages: { [key: string]: string } = {
-    'Configuration': 'Danny messed up configurating the authentication system. Please let me know about this.',
+    'configuration': 'Danny messed up configurating the authentication system. Please let me know about this.',
     'Verification': 'This verification token has expired.',
     'EmailCreateAccount': 'There was a problem creating your account. Please try again.',
     'EmailSignin': 'There was a problem sending the verification email. If the problem persists, please contact Danny.',

--- a/src/app/login/form.tsx
+++ b/src/app/login/form.tsx
@@ -4,8 +4,9 @@ import styles from "@/app/ui/form.module.css"
 import * as validation from '@/app/lib/validation'
 import { Button } from '@/app/ui/client-components'
 import { signIn } from 'next-auth/react'
+import { Subtitle } from '../ui/components'
 
-export default function Form({ initialEmail }: { initialEmail: string | null }) {
+const EnterEmail = ({ initialEmail, onSuccess }: { initialEmail: string | null, onSuccess: (email: string) => void }) => {
     const [email, setEmail] = React.useState(initialEmail || '')
     const [disabled, setDisabled] = React.useState(true)
 
@@ -20,14 +21,63 @@ export default function Form({ initialEmail }: { initialEmail: string | null }) 
     const [pending, setPending] = React.useState(false)
     const buttonDisabled = disabled || pending
     const handleSubmit: MouseEventHandler = async (e) => {
+        console.log(email)
         setPending(true)
-        await signIn('email', { email })
+        const res = await signIn('email', { email, redirect: false })
         setPending(false)
+        if (res?.error) {
+            if (res?.url) {
+                window.location.replace(res.url);
+            }
+        } else {
+            onSuccess(email);
+        }
     }
-    return <form>
+    return <form onSubmit={(e) => e.preventDefault()}>
         <div className={styles.formSection}>
             <input id="email" name="email" type="email" placeholder="Email" className={styles.textInput} required={true} value={email} onChange={e => setEmail(e.target.value)} />
-            <Button disabled={buttonDisabled} pending={pending} label="Send me a link" pendingLabel="Sending..." role="success" onClick={handleSubmit} />
+            <Button disabled={buttonDisabled} pending={pending} label="Send me a code" pendingLabel="Sending..." role="success" onClick={handleSubmit} />
         </div>
+        <Subtitle>Tally will email you a code to create your account or login to your existing account.</Subtitle>
     </form>
+}
+
+const VerifyCode = ({ email }: { email: string }) => {
+    const [code, setCode] = React.useState('')
+    const [disabled, setDisabled] = React.useState(true)
+
+    React.useEffect(() => {
+        setDisabled(!code)
+    }, [code])
+
+    const handleSubmit = () => {
+        window.location.href =
+            `/api/auth/callback/email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(code)}&callbackUrl=${encodeURIComponent('/?message=loginSuccess')}`
+    }
+
+    return <form onSubmit={(e) => e.preventDefault()}>
+        <div className={styles.formSection}>
+            <input
+                id="code"
+                name="code"
+                type="text"
+                placeholder="Verification code"
+                autoComplete='one-time-code'
+                className={styles.textInput}
+                required={true}
+                value={code} onChange={e => setCode(e.target.value)} />
+            <Button disabled={disabled} label="Verify" role="success" onClick={handleSubmit} />
+        </div>
+        <Subtitle>Enter the code you received in your email.</Subtitle>
+    </form>
+}
+
+export default function Form({ initialEmail }: { initialEmail: string | null }) {
+    const [verifyingEmail, setVerifyingEmail] = React.useState('')
+
+    if (!!verifyingEmail) {
+        return <VerifyCode email={verifyingEmail} />
+    }
+
+    return <EnterEmail initialEmail={initialEmail} onSuccess={(email) => setVerifyingEmail(email)} />
 }

--- a/src/app/login/form.tsx
+++ b/src/app/login/form.tsx
@@ -3,12 +3,14 @@ import React, { MouseEventHandler } from 'react'
 import styles from "@/app/ui/form.module.css"
 import * as validation from '@/app/lib/validation'
 import { Button } from '@/app/ui/client-components'
-import { signIn } from 'next-auth/react'
+import { signIn, SignInOptions } from 'next-auth/react'
 import { Subtitle } from '../ui/components'
+import { useRouter } from 'next/navigation'
 
 const EnterEmail = ({ initialEmail, onSuccess }: { initialEmail: string | null, onSuccess: (email: string) => void }) => {
     const [email, setEmail] = React.useState(initialEmail || '')
     const [disabled, setDisabled] = React.useState(true)
+    const router = useRouter()
 
     React.useEffect(() => {
         if (validation.email(email)) {
@@ -21,15 +23,17 @@ const EnterEmail = ({ initialEmail, onSuccess }: { initialEmail: string | null, 
     const [pending, setPending] = React.useState(false)
     const buttonDisabled = disabled || pending
     const handleSubmit: MouseEventHandler = async (e) => {
-        console.log(email)
         setPending(true)
         const res = await signIn('email', { email, redirect: false })
         setPending(false)
         if (res?.error) {
             if (res?.url) {
-                window.location.replace(res.url);
+                router.replace(res.url);
+            } else {
+                router.replace(`/login?error=${encodeURIComponent(res.error)}`)
             }
         } else {
+            router.replace('/login')
             onSuccess(email);
         }
     }
@@ -45,14 +49,21 @@ const EnterEmail = ({ initialEmail, onSuccess }: { initialEmail: string | null, 
 const VerifyCode = ({ email }: { email: string }) => {
     const [code, setCode] = React.useState('')
     const [disabled, setDisabled] = React.useState(true)
+    const router = useRouter()
 
     React.useEffect(() => {
         setDisabled(!code)
     }, [code])
 
-    const handleSubmit = () => {
-        window.location.href =
-            `/api/auth/callback/email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(code)}&callbackUrl=${encodeURIComponent('/?message=loginSuccess')}`
+    const handleSubmit = async () => {
+        const res = await fetch(`/api/auth/callback/email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(code)}&callbackUrl=${encodeURIComponent('/login-success')}`)
+        const redirectUrl = res.url
+        // this is hacky, but the alternative leads to a terrible UX of multiple reloads before we land on the user page
+        if (redirectUrl.includes('/login-success')) {
+            router.refresh() // this will redirect to the user page
+        } else {
+            router.replace('/login?error=Verification')
+        }
     }
 
     return <form onSubmit={(e) => e.preventDefault()}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Heading, Subtitle } from '@/app/ui/components'
+import { Box, Heading } from '@/app/ui/components'
 import Form from './form'
 import { Metadata } from 'next'
 import { redirectIfLoggedIn } from '../lib/hooks'
@@ -16,7 +16,6 @@ export default async function Page({ searchParams }: { searchParams?: any }) {
             <Heading>Log in to Tally</Heading>
             <AuthError />
             <Form initialEmail={email} />
-            <Subtitle>Tally will email you a link to create your account or login to your existing account.</Subtitle>
         </Box>
     </main>
 }


### PR DESCRIPTION
Kind of frankensteins the existing email provider flow to allow this. See issue [here](https://github.com/nextauthjs/next-auth/issues/709) and example solution [here](https://www.ramielcreations.com/nexth-auth-magic-code).

- [x] new flow works
- [x] fix success flow multiple refreshes